### PR TITLE
Add optional channel filter exclude for list of entries.

### DIFF
--- a/src/com/tivo/kmttg/gui/dialog/configAuto.java
+++ b/src/com/tivo/kmttg/gui/dialog/configAuto.java
@@ -30,6 +30,8 @@ import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Stack;
+import java.util.Arrays;
+import java.util.ArrayList;
 
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -101,6 +103,7 @@ public class configAuto {
    private static JTextField check_interval = null;
    private static JTextField comskipIni = null;
    private static JTextField channelFilter = null;
+   private static JCheckBox chlExcludes = null;
    private static JTextField tivoFileNameFormat = null;
    private static JCheckBox dateFilter = null;
    private static JCheckBox suggestionsFilter = null;
@@ -283,6 +286,8 @@ public class configAuto {
       JLabel channelFilter_label = new JLabel("channel filter: ");
       channelFilter = new JTextField(); channelFilter.setMinimumSize(new java.awt.Dimension(30, channelFilter.getPreferredSize().height));
 
+      chlExcludes = new JCheckBox("Exclude channels");
+
       JLabel tivoFileNameFormat_label = new JLabel("file name override: ");
       tivoFileNameFormat = new JTextField(); tivoFileNameFormat.setMinimumSize(new java.awt.Dimension(30, tivoFileNameFormat.getPreferredSize().height));
 
@@ -387,8 +392,9 @@ public class configAuto {
       JPanel gp = new JPanel(new MigLayout("", "[][grow]", ""));
       gp.add(encoding_name_label, "cell 0 0"); gp.add(row5, "cell 1 0, growx");
       gp.add(comskipIni_label, "cell 0 1"); gp.add(comskipIni, "cell 1 1, growx");
-      gp.add(channelFilter_label, "cell 0 2"); gp.add(channelFilter, "cell 1 2, growx");
-      gp.add(tivoFileNameFormat_label, "cell 0 3"); gp.add(tivoFileNameFormat, "cell 1 3, growx");
+      gp.add(tivoFileNameFormat_label, "cell 0 2"); gp.add(tivoFileNameFormat, "cell 1 2, growx");
+      gp.add(chlExcludes, "cell 0 3");
+      gp.add(channelFilter_label, "cell 0 4"); gp.add(channelFilter, "cell 1 4, growx");
       content.add(createBoxItemLJ(gp));
 
       // row_misc
@@ -493,6 +499,7 @@ public class configAuto {
       update.setToolTipText(getToolTip("update"));
       del.setToolTipText(getToolTip("del"));
       dateFilter.setToolTipText(getToolTip("dateFilter"));
+      chlExcludes.setToolTipText(getToolTip("chlExcludes"));
       suggestionsFilter.setToolTipText(getToolTip("suggestionsFilter"));
       suggestionsFilter_single.setToolTipText(getToolTip("suggestionsFilter_single"));
       useProgramId_unique.setToolTipText(getToolTip("useProgramId_unique"));
@@ -560,6 +567,10 @@ public class configAuto {
          text += "If you wish to use a specific comskip.ini file to use with <b>comcut</b> for<br>";
          text += "this auto transfer then specify the full path to the file here.<br>";
          text += "This will override the comskip.ini file specified in main kmttg configuration.";
+      }
+      else if (component.equals("chlExcludes")) {
+         text = "<b>Ignore channel list</b><br>";
+         text += "Treat channel list as channels to ignore recordings from.";
       }
       else if (component.equals("channelFilter")) {
          text =  "<b>channel filter</b><br>";
@@ -807,6 +818,7 @@ public class configAuto {
       dry_run.setSelected((Boolean)(autoConfig.dryrun == 1));
       noJobWait.setSelected((Boolean)(autoConfig.noJobWait == 1));
       dateFilter.setSelected((Boolean)(autoConfig.dateFilter == 1));
+      chlExcludes.setSelected((Boolean)(autoConfig.channelExcludes == 1));
       dateOperator.setSelectedItem(autoConfig.dateOperator);
       dateHours.setText("" + autoConfig.dateHours);
       suggestionsFilter.setSelected((Boolean)(autoConfig.suggestionsFilter == 1));
@@ -1016,6 +1028,7 @@ public class configAuto {
                ofp.write("encode "              + entry.encode              + "\n");
                //ofp.write("push "                + entry.push                + "\n");
                ofp.write("custom "              + entry.custom              + "\n");
+               ofp.write("channelExcludes "     + entry.channelExcludes     + "\n");
                ofp.write("suggestionsFilter "   + entry.suggestionsFilter   + "\n");
                ofp.write("useProgramId_unique " + entry.useProgramId_unique + "\n");
                if (entry.encode_name != null && entry.encode_name.length() > 0)
@@ -1081,6 +1094,7 @@ public class configAuto {
 
       comskipIni.setText(entry.comskipIni);
 
+      chlExcludes.setSelected((Boolean)(entry.channelExcludes == 1));
       if (entry.channelFilter != null)
          channelFilter.setText(entry.channelFilter);
       else
@@ -1205,11 +1219,19 @@ public class configAuto {
       }
       entry.comskipIni = ini;
 
-      String cFilter = (String)string.removeLeadingTrailingSpaces(channelFilter.getText());
-      if (cFilter.length() > 0)
-         entry.channelFilter = cFilter;
+      if (chlExcludes.isSelected())
+         entry.channelExcludes = 1;
       else
+         entry.channelExcludes = 0;
+
+      String cFilter = (String)string.removeLeadingTrailingSpaces(channelFilter.getText());
+      if (cFilter.length() > 0) {
+         entry.channelFilter = cFilter;
+         entry.channelFilterList = Arrays.asList(cFilter.split("\\s*,\\s*"));
+      } else {
          entry.channelFilter = null;
+         entry.channelFilterList = new ArrayList<String>();
+      }
 
       cFilter = (String)string.removeLeadingTrailingSpaces(tivoFileNameFormat.getText());
       if (cFilter.length() > 0)

--- a/src/com/tivo/kmttg/main/auto.java
+++ b/src/com/tivo/kmttg/main/auto.java
@@ -368,7 +368,7 @@ public class auto {
    private static Boolean filterByTivoName(Hashtable<String,String>entry, autoEntry auto) {
       if ( ! auto.tivo.equals("all") ) {
          if ( ! auto.tivo.equals(entry.get("tivoName")) ) {
-            log.print("NOTE: no match due to tivo name filter - tivo: " +
+            debug.print("NOTE: no match due to tivo name filter - tivo: " +
                   auto.tivo + ", entry: " + entry.get("title"));
             return true;
          }
@@ -397,7 +397,7 @@ public class auto {
             }               
          }
          if (filter) {
-            log.print("NOTE: no match due to Date Filter - " + entry.get("title") + ", age=" + diffStr + " hours");
+            debug.print("NOTE: no match due to Date Filter - " + entry.get("title") + ", age=" + diffStr + " hours");
          }
       }
       return filter;
@@ -452,20 +452,36 @@ public class auto {
    
    // Return true if should be filtered out because auto.channelFilter set and entry does not match it
    private static Boolean filterChannel(Hashtable<String,String>entry, autoEntry auto) {
-      Boolean filter = false; 
+      // Assume no match if no filter
+      Boolean filter = false;
+
       if (auto.channelFilter != null) {
-         filter = true;
+         String cmatch = null;
+         filter = (auto.channelExcludes == 1) ? false : true;
+         // Check channel numbers first
          if (entry.containsKey("channelNum")) {
-            if (entry.get("channelNum").equals(auto.channelFilter))
-               filter = false;
+            for (int i = 0; i <= auto.channelFilterList.size() - 1; i++) {
+               if (entry.get("channelNum").equals(auto.channelFilterList.get(i))) {
+                  cmatch = entry.get("channelNum");
+                  filter = !filter;
+                  break;
+               }
+            }
          }
-         if (entry.containsKey("channel")) {
-            if (entry.get("channel").equals(auto.channelFilter))
-               filter = false;
+         // Check channel name list if no match yet
+         if (cmatch == null && entry.containsKey("channel")) {
+            for (int i = 0; i <= auto.channelFilterList.size() - 1; i++) {
+               if (entry.get("channel").equals(auto.channelFilterList.get(i))) {
+                  cmatch = entry.get("channel");
+                  filter = !filter;
+                  break;
+               }
+            }
          }
-         
-         if (filter) {
-            log.print("NOTE: Filtered out due to channel filter = '" + auto.channelFilter + "' - " + entry.get("title"));
+         // Note action in log if match found
+         if (cmatch != null) {
+            String action = (auto.channelExcludes == 1) ? "Excluded" : "Selected";
+            log.print("NOTE: " + action + " due to channel filter match = '" + cmatch + "' - " + entry.get("title"));
          }
       }
       return filter;

--- a/src/com/tivo/kmttg/main/autoConfig.java
+++ b/src/com/tivo/kmttg/main/autoConfig.java
@@ -21,6 +21,7 @@ package com.tivo.kmttg.main;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Stack;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -35,6 +36,7 @@ public class autoConfig {
    public static int dryrun = 0;
    public static int CHECK_TIVOS_INTERVAL = 60;
    public static int dateFilter = 0;
+   public static int channelExcludes = 0;
    public static String dateOperator = "less than";
    public static float dateHours = 48;
    public static int suggestionsFilter = 0;
@@ -179,8 +181,11 @@ public class autoConfig {
                   entry.suggestionsFilter = Integer.parseInt(value);
                if (name.matches("useProgramId_unique"))
                   entry.useProgramId_unique = Integer.parseInt(value);
+               if (name.matches("channelExcludes"))
+                  entry.channelExcludes = Integer.parseInt(value);
                if (name.matches("channelFilter")) {
                   entry.channelFilter = value;
+                  entry.channelFilterList = Arrays.asList(value.split("\\s*,\\s*"));
                }
                if (name.matches("encode_name")) {
                   // encode_name value can have spaces

--- a/src/com/tivo/kmttg/main/autoEntry.java
+++ b/src/com/tivo/kmttg/main/autoEntry.java
@@ -19,6 +19,8 @@
 package com.tivo.kmttg.main;
 
 import java.util.Stack;
+import java.util.ArrayList;
+import java.util.List;
 
 public class autoEntry {
    public String type = null;
@@ -47,6 +49,8 @@ public class autoEntry {
    public int suggestionsFilter = 0;
    public int useProgramId_unique = 0;
    public String channelFilter = null;
+   public int channelExcludes = 0;
+   public List<String> channelFilterList = new ArrayList<String>();
    public String tivoFileNameFormat = null;
    
    public String toString() {


### PR DESCRIPTION
These changes implement the option to have the channel filter in `Auto Transfer` to be either a list of channels to only consider or a list to be ignored. The UI had an added element that selects which mode the filter acts in.

I have used this feature for a number of years and it works well. I have a rule for one of my Tivos which will fetch all recordings (`.*`) except those listed in the channel filter. Usually, I exclude all the mpeg4 channels on a S3 which cannot be transferred as-is.

I hope others may find this useful.